### PR TITLE
Don't hardcode errno constants

### DIFF
--- a/libarchive/write.py
+++ b/libarchive/write.py
@@ -2,6 +2,7 @@ from __future__ import division, print_function, unicode_literals
 
 from contextlib import contextmanager
 from ctypes import byref, cast, c_char, c_size_t, c_void_p, POINTER
+from errno import EISDIR
 
 from . import ffi
 from .entry import ArchiveEntry, new_archive_entry
@@ -67,7 +68,7 @@ class ArchiveWrite(object):
                                         break
                                     write_data(write_p, data, len(data))
                         except IOError as e:
-                            if e.errno != 21:
+                            if e.errno != EISDIR:
                                 raise  # pragma: no cover
                         write_finish_entry(write_p)
                         entry_clear(entry_p)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,5 +1,7 @@
 from __future__ import division, print_function, unicode_literals
 
+from errno import ENOENT
+
 import pytest
 
 from libarchive import ArchiveError, ffi, memory_writer
@@ -10,7 +12,7 @@ def test_add_files_nonexistent():
         with pytest.raises(ArchiveError) as e:
             archive.add_files('nonexistent')
         assert e.value.msg
-        assert e.value.errno == 2
+        assert e.value.errno == ENOENT
         assert e.value.retcode == -25
 
 


### PR DESCRIPTION
The values of `ENOENT` and `EISDIR` are architecture-dependent, so don't assume they're always 2 and 21.

This bug was found using [pydiatra](https://github.com/jwilk/pydiatra).