### PR TITLE
Support c_ssize_t in python 2.6

### DIFF
--- a/libarchive/ffi.py
+++ b/libarchive/ffi.py
@@ -1,9 +1,15 @@
 from __future__ import division, print_function, unicode_literals
 
 from ctypes import (
-    c_char_p, c_int, c_uint, c_longlong, c_size_t, c_ssize_t, c_void_p,
+    c_char_p, c_int, c_uint, c_longlong, c_size_t, c_void_p,
     c_wchar_p, CFUNCTYPE, POINTER,
 )
+
+try:
+    from ctypes import c_ssize_t
+except ImportError:
+    from ctypes import c_longlong as c_ssize_t
+
 import ctypes
 from ctypes.util import find_library
 import logging


### PR DESCRIPTION
Support c_ssize_t in python 2.6

Python 2.6 currently was not in the test plan(https://github.com/Changaco/python-libarchive-c/blob/master/.travis.yml#L26), this patch just a workaround

close #36 