### PR TITLE
Add xdist for segfault detection

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,11 @@ skipsdist=True
 [testenv]
 passenv = LIBARCHIVE
 commands=
-    python -m pytest -vv --cov libarchive --cov-report term-missing {toxinidir}/tests {posargs}
+    python -m pytest -vv --boxed --cov libarchive --cov-report term-missing {toxinidir}/tests {posargs}
 deps=
     pytest
     pytest-cov
+    pytest-xdist
     six
     mock
 


### PR DESCRIPTION
pytest-xdist has a nice mode, --boxed, that along with running tests in
a separate subprocess, can also report on crashes due to libarchive
library misuse.

This allows pytest runs to detect libarchive segfaults and give us
better feedback when we misuse the C API via ctypes.

More information: https://pypi.python.org/pypi/pytest-xdist#boxed