### PR TITLE
Add custom_reader for archives

### DIFF
--- a/libarchive/__init__.py
+++ b/libarchive/__init__.py
@@ -1,13 +1,13 @@
 from .entry import ArchiveEntry
 from .exception import ArchiveError
 from .extract import extract_fd, extract_file, extract_memory
-from .read import fd_reader, file_reader, memory_reader
+from .read import custom_reader, fd_reader, file_reader, memory_reader
 from .write import custom_writer, fd_writer, file_writer, memory_writer
 
 __all__ = [
     ArchiveEntry,
     ArchiveError,
     extract_fd, extract_file, extract_memory,
-    fd_reader, file_reader, memory_reader,
+    custom_reader, fd_reader, file_reader, memory_reader,
     custom_writer, fd_writer, file_writer, memory_writer
 ]

--- a/libarchive/__init__.py
+++ b/libarchive/__init__.py
@@ -1,13 +1,13 @@
 from .entry import ArchiveEntry
 from .exception import ArchiveError
 from .extract import extract_fd, extract_file, extract_memory
-from .read import custom_reader, fd_reader, file_reader, memory_reader
+from .read import custom_reader, fd_reader, file_reader, memory_reader, stream_reader
 from .write import custom_writer, fd_writer, file_writer, memory_writer
 
 __all__ = [
     ArchiveEntry,
     ArchiveError,
     extract_fd, extract_file, extract_memory,
-    custom_reader, fd_reader, file_reader, memory_reader,
+    custom_reader, fd_reader, file_reader, memory_reader, stream_reader,
     custom_writer, fd_writer, file_writer, memory_writer
 ]

--- a/libarchive/ffi.py
+++ b/libarchive/ffi.py
@@ -44,6 +44,9 @@ DEFAULT_UNIX_PERMISSION = 0o664
 WRITE_CALLBACK = CFUNCTYPE(
     c_ssize_t, c_void_p, c_void_p, POINTER(c_void_p), c_size_t
 )
+READ_CALLBACK = CFUNCTYPE(
+    c_ssize_t, c_void_p, c_void_p, POINTER(c_void_p)
+)
 OPEN_CALLBACK = CFUNCTYPE(c_int, c_void_p, c_void_p)
 CLOSE_CALLBACK = CFUNCTYPE(c_int, c_void_p, c_void_p)
 VOID_CB = lambda *_: ARCHIVE_OK
@@ -170,6 +173,9 @@ for f_name in list(READ_FILTERS):
         logger.warning('read filter "%s" is not supported' % f_name)
         READ_FILTERS.remove(f_name)
 
+ffi('read_open',
+    [c_archive_p, c_void_p, OPEN_CALLBACK, READ_CALLBACK, CLOSE_CALLBACK],
+    c_int, check_int)
 ffi('read_open_fd', [c_archive_p, c_int, c_size_t], c_int, check_int)
 ffi('read_open_filename_w', [c_archive_p, c_wchar_p, c_size_t],
     c_int, check_int)

--- a/tests/test_rwx.py
+++ b/tests/test_rwx.py
@@ -80,28 +80,18 @@ def test_files(tmpdir):
         assert tree2 == tree
 
 
-def test_custom():
+def test_custom_writer_and_stream_reader():
     # Collect information on what should be in the archive
     tree = treestat('libarchive')
 
     # Create an archive of our libarchive/ directory
-    blocks = []
-
-    def write_cb(data):
-        blocks.append(data[:])
-        return len(data)
-
-    with libarchive.custom_writer(write_cb, 'zip') as archive:
+    stream = io.BytesIO()
+    with libarchive.custom_writer(stream.write, 'zip') as archive:
         archive.add_files('libarchive/')
-        pass
-
-    # the custom_reader needs a read function, so we'll use
-    # BytesIO to provide that from our in-memory buf
-    buf = b''.join(blocks)
-    reader = io.BytesIO(buf)
+    stream.seek(0)
 
     # Read the archive and check that the data is correct
-    with libarchive.custom_reader(reader.readinto, 'zip') as archive:
+    with libarchive.stream_reader(stream, 'zip') as archive:
         check_archive(archive, tree)
 
 

--- a/tests/test_rwx.py
+++ b/tests/test_rwx.py
@@ -1,6 +1,7 @@
 """Test reading, writing and extracting archives."""
 
 from __future__ import division, print_function, unicode_literals
+import io
 
 import libarchive
 from libarchive.extract import EXTRACT_OWNER, EXTRACT_PERM, EXTRACT_TIME
@@ -79,8 +80,7 @@ def test_files(tmpdir):
         assert tree2 == tree
 
 
-def test_custom_writer():
-
+def test_custom():
     # Collect information on what should be in the archive
     tree = treestat('libarchive')
 
@@ -95,9 +95,13 @@ def test_custom_writer():
         archive.add_files('libarchive/')
         pass
 
-    # Read the archive and check that the data is correct
+    # the custom_reader needs a read function, so we'll use
+    # BytesIO to provide that from our in-memory buf
     buf = b''.join(blocks)
-    with libarchive.memory_reader(buf) as archive:
+    reader = io.BytesIO(buf)
+
+    # Read the archive and check that the data is correct
+    with libarchive.custom_reader(reader.readinto, 'zip') as archive:
         check_archive(archive, tree)
 
 


### PR DESCRIPTION
It is fairly typical for Python file objects to be used on the read side
of archive processing. For instance, io.BufferedReader and similar
API that handles I/O itself.

To allow for libarchive interaction with these objects, we need a
custom_reader that can use the `readinto()` style access to the raw
archive data. `readinto()` is used as that allows us to read the data
into a `ctypes.create_string_buffer()` structure and easily cast the
pointers for the read callback. The preallocated buffer also ensures
that libarchive gets access to contiguous memory and that buffer isn't
garbage collected by Python after the callback returns.