### PR TITLE
Reduce unnecessary log noise

### DIFF
--- a/libarchive/ffi.py
+++ b/libarchive/ffi.py
@@ -162,7 +162,7 @@ for f_name in list(READ_FORMATS):
     try:
         ffi('read_support_format_'+f_name, [c_archive_p], c_int, check_int)
     except AttributeError:  # pragma: no cover
-        logger.warning('read format "%s" is not supported' % f_name)
+        logger.info('read format "%s" is not supported' % f_name)
         READ_FORMATS.remove(f_name)
 
 READ_FILTERS = set((
@@ -173,7 +173,7 @@ for f_name in list(READ_FILTERS):
     try:
         ffi('read_support_filter_'+f_name, [c_archive_p], c_int, check_int)
     except AttributeError:  # pragma: no cover
-        logger.warning('read filter "%s" is not supported' % f_name)
+        logger.info('read filter "%s" is not supported' % f_name)
         READ_FILTERS.remove(f_name)
 
 ffi('read_open',
@@ -224,7 +224,7 @@ for f_name in list(WRITE_FORMATS):
     try:
         ffi('write_set_format_'+f_name, [c_archive_p], c_int, check_int)
     except AttributeError:  # pragma: no cover
-        logger.warning('write format "%s" is not supported' % f_name)
+        logger.info('write format "%s" is not supported' % f_name)
         WRITE_FORMATS.remove(f_name)
 
 WRITE_FILTERS = set((
@@ -235,7 +235,7 @@ for f_name in list(WRITE_FILTERS):
     try:
         ffi('write_add_filter_'+f_name, [c_archive_p], c_int, check_int)
     except AttributeError:  # pragma: no cover
-        logger.warning('write filter "%s" is not supported' % f_name)
+        logger.info('write filter "%s" is not supported' % f_name)
         WRITE_FILTERS.remove(f_name)
 
 ffi('write_open',


### PR DESCRIPTION
Currently a warning level log message is produced for each read/write format and filter that's not available. This adds to log clutter and can trigger automated alerts. These should be informational messages.

Fixes #74