### PR TITLE
Allow timestamps for add_file_from_memory

### DIFF
--- a/libarchive/write.py
+++ b/libarchive/write.py
@@ -77,12 +77,8 @@ class ArchiveWrite(object):
 
     def add_file_from_memory(
             self, entry_path, entry_size, entry_data,
-            filetype=REGULAR_FILE,
-            permission=DEFAULT_UNIX_PERMISSION,
-            atime=None,
-            mtime=None,
-            ctime=None,
-            birthtime=None,
+            filetype=REGULAR_FILE, permission=DEFAULT_UNIX_PERMISSION,
+            atime=None, mtime=None, ctime=None, birthtime=None,
     ):
         """"Add file from memory to archive.
 
@@ -124,21 +120,21 @@ class ArchiveWrite(object):
             entry_set_perm(archive_entry_pointer, permission)
 
             if atime is not None:
-                archive_entry.set_atime(*(
-                    (atime, 0)
-                    if isinstance(atime, (int, float)) else atime))
+                if not isinstance(atime, tuple):
+                    atime = (atime, 0)
+                archive_entry.set_atime(*atime)
             if mtime is not None:
-                archive_entry.set_mtime(*(
-                    (mtime, 0)
-                    if isinstance(mtime, (int, float)) else mtime))
+                if not isinstance(mtime, tuple):
+                    mtime = (mtime, 0)
+                archive_entry.set_mtime(*mtime)
             if ctime is not None:
-                archive_entry.set_ctime(*(
-                    (ctime, 0)
-                    if isinstance(ctime, (int, float)) else ctime))
+                if not isinstance(ctime, tuple):
+                    ctime = (ctime, 0)
+                archive_entry.set_ctime(*ctime)
             if birthtime is not None:
-                archive_entry.set_birthtime(*(
-                    (birthtime, 0)
-                    if isinstance(birthtime, (int, float)) else birthtime))
+                if not isinstance(birthtime, tuple):
+                    birthtime = (birthtime, 0)
+                archive_entry.set_birthtime(*birthtime)
             write_header(archive_pointer, archive_entry_pointer)
 
             for chunk in entry_data:

--- a/libarchive/write.py
+++ b/libarchive/write.py
@@ -78,7 +78,11 @@ class ArchiveWrite(object):
     def add_file_from_memory(
             self, entry_path, entry_size, entry_data,
             filetype=REGULAR_FILE,
-            permission=DEFAULT_UNIX_PERMISSION
+            permission=DEFAULT_UNIX_PERMISSION,
+            atime=None,
+            mtime=None,
+            ctime=None,
+            birthtime=None,
     ):
         """"Add file from memory to archive.
 
@@ -93,6 +97,14 @@ class ArchiveWrite(object):
         :type filetype: octal number
         :param permission: with which permission should entry be created
         :type permission: octal number
+        :param atime: Last access time
+        :type atime: int seconds or tuple (int seconds, int nanoseconds)
+        :param mtime: Last modified time
+        :type mtime: int seconds or tuple (int seconds, int nanoseconds)
+        :param ctime: Creation time
+        :type ctime: int seconds or tuple (int seconds, int nanoseconds)
+        :param birthtime: Birth time (for archive formats that support it)
+        :type birthtime: int seconds or tuple (int seconds, int nanoseconds)
         """
         archive_pointer = self._pointer
 
@@ -110,6 +122,23 @@ class ArchiveWrite(object):
             entry_set_size(archive_entry_pointer, entry_size)
             entry_set_filetype(archive_entry_pointer, filetype)
             entry_set_perm(archive_entry_pointer, permission)
+
+            if atime is not None:
+                archive_entry.set_atime(*(
+                    (atime, 0)
+                    if isinstance(atime, (int, float)) else atime))
+            if mtime is not None:
+                archive_entry.set_mtime(*(
+                    (mtime, 0)
+                    if isinstance(mtime, (int, float)) else mtime))
+            if ctime is not None:
+                archive_entry.set_ctime(*(
+                    (ctime, 0)
+                    if isinstance(ctime, (int, float)) else ctime))
+            if birthtime is not None:
+                archive_entry.set_birthtime(*(
+                    (birthtime, 0)
+                    if isinstance(birthtime, (int, float)) else birthtime))
             write_header(archive_pointer, archive_entry_pointer)
 
             for chunk in entry_data:

--- a/tests/test_rwx.py
+++ b/tests/test_rwx.py
@@ -6,6 +6,7 @@ import io
 import json
 
 import libarchive
+from libarchive.entry import format_time
 from libarchive.extract import EXTRACT_OWNER, EXTRACT_PERM, EXTRACT_TIME
 from libarchive.write import memory_writer
 from mock import patch
@@ -156,3 +157,10 @@ def test_adding_entry_from_memory(archfmt, data_bytes):
             actual = b''.join(archive_entry.get_blocks())
             assert expected == actual
             assert archive_entry.path == entry_path
+            assert archive_entry.atime in (atime[0], format_time(*atime))
+            assert archive_entry.mtime in (mtime[0], format_time(*mtime))
+            assert archive_entry.ctime in (ctime[0], format_time(*ctime))
+            if has_birthtime:
+                assert archive_entry.birthtime in (
+                    btime[0], format_time(*btime)
+                )

--- a/tests/test_rwx.py
+++ b/tests/test_rwx.py
@@ -131,12 +131,23 @@ def test_adding_entry_from_memory(archfmt, data_bytes):
 
     blocks = []
 
+    archfmt = 'zip'
+    has_birthtime = archfmt != 'zip'
+
+    atime = (1482144741, 495628118)
+    mtime = (1482155417, 659017086)
+    ctime = (1482145211, 536858081)
+    btime = (1482144740, 495628118) if has_birthtime else None
+
     def write_callback(data):
         blocks.append(data[:])
         return len(data)
 
     with libarchive.custom_writer(write_callback, archfmt) as archive:
-        archive.add_file_from_memory(entry_path, entry_size, entry_data)
+        archive.add_file_from_memory(
+            entry_path, entry_size, entry_data,
+            atime=atime, mtime=mtime, ctime=ctime, birthtime=btime
+        )
 
     buf = b''.join(blocks)
     with libarchive.memory_reader(buf) as memory_archive:


### PR DESCRIPTION
Currently, any file entry added using `add_file_from_memory()` is saved with uninformative epoch-zero timestamps.

This is a backward-compatible enhancement designed to allow the user to add timestamps of their choosing to archives created with this method, without cumbersome workarounds, patches, or code forks.

Closes #73