### PR TITLE
Python 3.8: tarfile.filemode is gone, use stat.filemode if available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 matrix:
   include:
     - python: 3.5
-      env: TOXENV=py27,py34,py35
+      env: TOXENV=py27,py35
     - python: 3.6
       env: TOXENV=py36
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
       env: TOXENV=py27,py35
     - python: 3.6
       env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
 
 branches:
   only:
@@ -35,4 +37,4 @@ notifications:
   email: false
 
 sudo: required
-dist: trusty
+dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
+    - python: 3.8-dev
+      env: TOXENV=py38
 
 branches:
   only:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,6 +6,10 @@ from os import chdir, getcwd, stat, walk
 from os.path import abspath, dirname, join
 from stat import S_ISREG
 import tarfile
+try:
+    from stat import filemode
+except ImportError:  # Python 2
+    filemode = tarfile.filemode
 
 from libarchive import file_reader
 
@@ -83,7 +87,7 @@ def get_tarinfos(location):
                 path += '/'
             # libarchive introduces prefixes such as h prefix for
             # hardlinks: tarfile does not, so we ignore the first char
-            mode = tarfile.filemode(entry.mode)[1:]
+            mode = filemode(entry.mode)[1:]
             yield {
                 'path': path,
                 'mtime': entry.mtime,

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skipsdist=True
 [testenv]
 passenv = LIBARCHIVE
 commands=
-    python -m pytest -vv --boxed --cov libarchive --cov-report term-missing {toxinidir}/tests {posargs}
+    python -m pytest -Wd -vv --boxed --cov libarchive --cov-report term-missing {toxinidir}/tests {posargs}
     flake8 {toxinidir}
 deps=
     flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36,py37,py38
+envlist=py27,py35,py36,py37,py38
 skipsdist=True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36
+envlist=py27,py34,py35,py36,py37,py38
 skipsdist=True
 
 [testenv]


### PR DESCRIPTION
    >           mode = tarfile.filemode(entry.mode)[1:]
    E           AttributeError: module 'tarfile' has no attribute 'filemode'