### PR TITLE
Add zstd support

### DIFF
--- a/libarchive/ffi.py
+++ b/libarchive/ffi.py
@@ -167,7 +167,7 @@ for f_name in list(READ_FORMATS):
 
 READ_FILTERS = set((
     'all', 'bzip2', 'compress', 'grzip', 'gzip', 'lrzip', 'lzip', 'lzma',
-    'lzop', 'none', 'rpm', 'uu', 'xz', 'lz4'
+    'lzop', 'none', 'rpm', 'uu', 'xz', 'lz4', 'zstd'
 ))
 for f_name in list(READ_FILTERS):
     try:
@@ -229,7 +229,7 @@ for f_name in list(WRITE_FORMATS):
 
 WRITE_FILTERS = set((
     'b64encode', 'bzip2', 'compress', 'grzip', 'gzip', 'lrzip', 'lzip', 'lzma',
-    'lzop', 'uuencode', 'xz', 'lz4'
+    'lzop', 'uuencode', 'xz', 'lz4', 'zstd'
 ))
 for f_name in list(WRITE_FILTERS):
     try:


### PR DESCRIPTION
Anaconda has been carrying this in their build of libarchive-c for a while:

https://github.com/AnacondaRecipes/python-libarchive-c-feedstock/tree/master/recipe