### PR TITLE
Load extra formats and filters when they're requested

### DIFF
--- a/libarchive/ffi.py
+++ b/libarchive/ffi.py
@@ -101,6 +101,50 @@ def ffi(name, argtypes, restype, errcheck=None):
     return f
 
 
+def get_read_format_function(format_name):
+    function_name = 'read_support_format_' + format_name
+    func = globals().get(function_name)
+    if func:
+        return func
+    try:
+        return ffi(function_name, [c_archive_p], c_int, check_int)
+    except AttributeError:
+        raise ValueError('the read format %r is not available' % format_name)
+
+
+def get_read_filter_function(filter_name):
+    function_name = 'read_support_filter_' + filter_name
+    func = globals().get(function_name)
+    if func:
+        return func
+    try:
+        return ffi(function_name, [c_archive_p], c_int, check_int)
+    except AttributeError:
+        raise ValueError('the read filter %r is not available' % filter_name)
+
+
+def get_write_format_function(format_name):
+    function_name = 'write_set_format_' + format_name
+    func = globals().get(function_name)
+    if func:
+        return func
+    try:
+        return ffi(function_name, [c_archive_p], c_int, check_int)
+    except AttributeError:
+        raise ValueError('the write format %r is not available' % format_name)
+
+
+def get_write_filter_function(filter_name):
+    function_name = 'write_add_filter_' + filter_name
+    func = globals().get(function_name)
+    if func:
+        return func
+    try:
+        return ffi(function_name, [c_archive_p], c_int, check_int)
+    except AttributeError:
+        raise ValueError('the write filter %r is not available' % filter_name)
+
+
 # FFI declarations
 
 # archive_util
@@ -160,9 +204,9 @@ READ_FORMATS = set((
 ))
 for f_name in list(READ_FORMATS):
     try:
-        ffi('read_support_format_'+f_name, [c_archive_p], c_int, check_int)
-    except AttributeError:  # pragma: no cover
-        logger.info('read format "%s" is not supported' % f_name)
+        get_read_format_function(f_name)
+    except ValueError as e:  # pragma: no cover
+        logger.info(str(e))
         READ_FORMATS.remove(f_name)
 
 READ_FILTERS = set((
@@ -171,9 +215,9 @@ READ_FILTERS = set((
 ))
 for f_name in list(READ_FILTERS):
     try:
-        ffi('read_support_filter_'+f_name, [c_archive_p], c_int, check_int)
-    except AttributeError:  # pragma: no cover
-        logger.info('read filter "%s" is not supported' % f_name)
+        get_read_filter_function(f_name)
+    except ValueError as e:  # pragma: no cover
+        logger.info(str(e))
         READ_FILTERS.remove(f_name)
 
 ffi('read_open',
@@ -222,9 +266,9 @@ WRITE_FORMATS = set((
 ))
 for f_name in list(WRITE_FORMATS):
     try:
-        ffi('write_set_format_'+f_name, [c_archive_p], c_int, check_int)
-    except AttributeError:  # pragma: no cover
-        logger.info('write format "%s" is not supported' % f_name)
+        get_write_format_function(f_name)
+    except ValueError as e:  # pragma: no cover
+        logger.info(str(e))
         WRITE_FORMATS.remove(f_name)
 
 WRITE_FILTERS = set((
@@ -233,9 +277,9 @@ WRITE_FILTERS = set((
 ))
 for f_name in list(WRITE_FILTERS):
     try:
-        ffi('write_add_filter_'+f_name, [c_archive_p], c_int, check_int)
-    except AttributeError:  # pragma: no cover
-        logger.info('write filter "%s" is not supported' % f_name)
+        get_write_filter_function(f_name)
+    except ValueError as e:  # pragma: no cover
+        logger.info(str(e))
         WRITE_FILTERS.remove(f_name)
 
 ffi('write_open',

--- a/libarchive/read.py
+++ b/libarchive/read.py
@@ -36,9 +36,9 @@ def new_archive_read(format_name='all', filter_name='all'):
     Returns a pointer if successful. Raises ArchiveError on error.
     """
     archive_p = ffi.read_new()
-    getattr(ffi, 'read_support_filter_'+filter_name)(archive_p)
-    getattr(ffi, 'read_support_format_'+format_name)(archive_p)
     try:
+        ffi.get_read_filter_function(filter_name)(archive_p)
+        ffi.get_read_format_function(format_name)(archive_p)
         yield archive_p
     finally:
         ffi.read_free(archive_p)

--- a/libarchive/write.py
+++ b/libarchive/write.py
@@ -149,14 +149,14 @@ class ArchiveWrite(object):
 @contextmanager
 def new_archive_write(format_name, filter_name=None, options=''):
     archive_p = ffi.write_new()
-    getattr(ffi, 'write_set_format_'+format_name)(archive_p)
-    if filter_name:
-        getattr(ffi, 'write_add_filter_'+filter_name)(archive_p)
-    if options:
-        if not isinstance(options, bytes):
-            options = options.encode('utf-8')
-        ffi.write_set_options(archive_p, options)
     try:
+        ffi.get_write_format_function(format_name)(archive_p)
+        if filter_name:
+            ffi.get_write_filter_function(filter_name)(archive_p)
+        if options:
+            if not isinstance(options, bytes):
+                options = options.encode('utf-8')
+            ffi.write_set_options(archive_p, options)
         yield archive_p
         ffi.write_close(archive_p)
         ffi.write_free(archive_p)


### PR DESCRIPTION
This commit modifies `new_archive_read` and `new_archive_write` to automatically look up the format and filter initialization functions if they haven't been loaded by default.