### PR TITLE
ARM64: Add ARM64 jobs in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,29 @@
 language: python
 matrix:
   include:
-    - python: 3.5
+    - arch: amd64
+      python: 3.5
       env: TOXENV=py27,py35
-    - python: 3.6
+    - arch: arm64
+      python: 3.5
+      env: TOXENV=py27,py35
+    - arch: amd64
+      python: 3.6
       env: TOXENV=py36
-    - python: 3.7
+    - arch: arm64
+      python: 3.6
+      env: TOXENV=py36
+    - arch: amd64
+      python: 3.7
       env: TOXENV=py37
-    - python: 3.8-dev
+    - arch: arm64
+      python: 3.7
+      env: TOXENV=py37
+    - arch: amd64
+      python: 3.8-dev
+      env: TOXENV=py38
+    - arch: arm64
+      python: 3.8-dev
       env: TOXENV=py38
 
 branches:


### PR DESCRIPTION
Travis-CI has added support for ARM64. Added ARM64 jobs in Travis-CI.