### PR TITLE
Adding Power support(ppc64le) with ci and testing to the project for architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,18 @@ matrix:
       env: TOXENV=py37
     - python: 3.8-dev
       env: TOXENV=py38
+    - python: 3.5
+      arch: ppc64le
+      env: TOXENV=py27,py35
+    - python: 3.6
+      env: TOXENV=py36
+      arch: ppc64le 
+    - python: 3.7
+      env: TOXENV=py37
+      arch: ppc64le
+    - python: 3.8-dev
+      env: TOXENV=py38
+      arch: ppc64le
 
 branches:
   only:


### PR DESCRIPTION
I am part of IBM team and working on porting power arch to packages as continuous integration & testing.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly,
we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.


Pls verify and merge
