### PR TITLE
libarchive-c: fix seek() handling

### DIFF
--- a/libarchive/ffi.py
+++ b/libarchive/ffi.py
@@ -47,7 +47,7 @@ READ_CALLBACK = CFUNCTYPE(
     c_ssize_t, c_void_p, c_void_p, POINTER(c_void_p)
 )
 SEEK_CALLBACK = CFUNCTYPE(
-    c_longlong, c_int, c_void_p, c_longlong, c_int
+    c_longlong, c_void_p, c_void_p, c_longlong, c_int
 )
 OPEN_CALLBACK = CFUNCTYPE(c_int, c_void_p, c_void_p)
 CLOSE_CALLBACK = CFUNCTYPE(c_int, c_void_p, c_void_p)

--- a/libarchive/read.py
+++ b/libarchive/read.py
@@ -143,9 +143,10 @@ def stream_reader(
     open_cb = NO_OPEN_CB
     read_cb = READ_CALLBACK(read_func)
     close_cb = NO_CLOSE_CB
+    seek_cb = SEEK_CALLBACK(seek_func)
     with new_archive_read(format_name, filter_name, passphrase) as archive_p:
         if stream.seekable():
-            ffi.read_set_seek_callback(archive_p, SEEK_CALLBACK(seek_func))
+            ffi.read_set_seek_callback(archive_p, seek_cb)
         ffi.read_open(archive_p, None, open_cb, read_cb, close_cb)
         yield ArchiveRead(archive_p)
 


### PR DESCRIPTION
seek() handling had two problems:
- seek callback had too short lifetime: it was garbage collected before
  C code gets executed during archive iteration.
- seek callback had wrong prototype: context pointer was passed as 'int'

As a result test suite was occasionally crashing in NixOS:

  ============================= test session starts ==============================
  platform linux -- Python 3.9.6, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
  rootdir: /build/source
  collected 33 items

  tests/test_atime_mtime_ctime.py ........                                 [ 24%]
  tests/test_convert.py .                                                  [ 27%]
  tests/test_entry.py .......                                              [ 48%]
  tests/test_errors.py ....                                                [ 60%]
  tests/test_rwx.py ...
  Program received signal SIGSEGV, Segmentation fault.
  0x00007fffe9314381 in classify_argument () from /nix/store/...-libffi-3.4.2/lib/libffi.so.8
  0  0x00007fffe9314381 in classify_argument () from /nix/store/...-libffi-3.4.2/lib/libffi.so.8
  1  0x00007fffe9315462 in ffi_closure_unix64_inner () from /nix/store/...-libffi-3.4.2/lib/libffi.so.8
  2  0x00007fffe93159a0 in ffi_closure_unix64 () from /nix/store/...-libffi-3.4.2/lib/libffi.so.8
  3  0x00007fffe9226287 in __archive_read_filter_seek () from /nix/store/...-libarchive-3.5.2-lib/lib/libarchive.so
  4  0x00007fffe925ff8a in archive_read_format_zip_seekable_bid () from /nix/store/...-libarchive-3.5.2-lib/lib/libarchive.so
  5  0x00007fffe92265e5 in archive_read_open1 () from /nix/store/...-libarchive-3.5.2-lib/lib/libarchive.so
  6  0x00007fffe931580a in ffi_call_unix64 () from /nix/store/...-libffi-3.4.2/lib/libffi.so.8
  7  0x00007fffe9314943 in ffi_call_int () from /nix/store/...-libffi-3.4.2/lib/libffi.so.8
  8  0x00007fffe932e015 in _ctypes_callproc () from /nix/store/...-python3-3.9.6/lib/python3.9/lib-dynload/_ctypes.cpython-39-x86_64-linux-gnu.so
  9  0x00007fffe932f992 in PyCFuncPtr_call () from /nix/store/...-python3-3.9.6/lib/python3.9/lib-dynload/_ctypes.cpython-39-x86_64-linux-gnu.so
  10 0x00007ffff7ca0750 in _PyObject_MakeTpCall () from /nix/store/...-python3-3.9.6/lib/libpython3.9.so.1.0
  11 0x00007ffff7c57f36 in _PyEval_EvalFrameDefault () from /nix/store/...-python3-3.9.6/lib/libpython3.9.so.1.0
  ...

The change fixes crashes for me.