### PR TITLE
Remove obsolete dependencies

### DIFF
--- a/tests/test_rwx.py
+++ b/tests/test_rwx.py
@@ -7,7 +7,7 @@ import libarchive
 from libarchive.entry import format_time
 from libarchive.extract import EXTRACT_OWNER, EXTRACT_PERM, EXTRACT_TIME
 from libarchive.write import memory_writer
-from mock import patch
+from unittest.mock import patch
 import pytest
 
 from . import check_archive, in_dir, treestat

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,3 @@ deps=
     pytest
     pytest-cov
     pytest-xdist
-    six

--- a/tox.ini
+++ b/tox.ini
@@ -13,4 +13,3 @@ deps=
     pytest-cov
     pytest-xdist
     six
-    mock


### PR DESCRIPTION
Remove the obsolete six dependency from `tox.ini`, and replace the external `mock` backport with built-in `unittest.mock` that's present since Python 3.3.