### PR TITLE
read PKG-INFO, README as utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@ from version import get_version
 
 os.umask(0o022)
 
+with open(join(dirname(__file__), 'README.rst'), encoding="utf-8") as f:
+    README = f.read()
+
 setup(
     name='libarchive-c',
     version=get_version(),
@@ -16,7 +19,7 @@ setup(
     url='https://github.com/Changaco/python-libarchive-c',
     license='CC0',
     packages=find_packages(exclude=['tests']),
-    long_description=open(join(dirname(__file__), 'README.rst'), encoding="utf-8").read(),
+    long_description=README,
     long_description_content_type='text/x-rst',
     keywords='archive libarchive 7z tar bz2 zip gz',
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url='https://github.com/Changaco/python-libarchive-c',
     license='CC0',
     packages=find_packages(exclude=['tests']),
-    long_description=open(join(dirname(__file__), 'README.rst')).read(encoding="utf-8"),
+    long_description=open(join(dirname(__file__), 'README.rst'), encoding="utf-8").read(),
     long_description_content_type='text/x-rst',
     keywords='archive libarchive 7z tar bz2 zip gz',
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url='https://github.com/Changaco/python-libarchive-c',
     license='CC0',
     packages=find_packages(exclude=['tests']),
-    long_description=open(join(dirname(__file__), 'README.rst')).read(),
+    long_description=open(join(dirname(__file__), 'README.rst')).read(encoding="utf-8"),
     long_description_content_type='text/x-rst',
     keywords='archive libarchive 7z tar bz2 zip gz',
 )

--- a/version.py
+++ b/version.py
@@ -35,7 +35,7 @@ def get_version():
 
     else:
         # Extract the version from the PKG-INFO file.
-        with open(join(d, 'PKG-INFO'), encoding="utf-8") as f:
+        with open(join(d, 'PKG-INFO'), encoding='utf-8', errors='replace') as f:
             version = version_re.search(f.read()).group(1)
 
     return version

--- a/version.py
+++ b/version.py
@@ -35,7 +35,7 @@ def get_version():
 
     else:
         # Extract the version from the PKG-INFO file.
-        with open(join(d, 'PKG-INFO')) as f:
+        with open(join(d, 'PKG-INFO'), encoding="utf-8") as f:
             version = version_re.search(f.read()).group(1)
 
     return version


### PR DESCRIPTION
Thanks for `python-libarchive-c`, and congratulations on 4.0! 

This tries to read `PKG-INFO` as `utf-8` to avoid situations like this, encountered downstream on [conda-forge](https://github.com/conda-forge/python-libarchive-c-feedstock/pull/31) ([log](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=445520&view=logs&j=00f5923e-fdef-5026-5091-0d5a0b3d5a2c&t=3cc4a9ed-60e1-5810-6eb3-5f9cd4a26dba&l=323)): 

```py
Processing d:\bld\python-libarchive-c_1642883867449\work\dist
  Added file:///D:/bld/python-libarchive-c_1642883867449/work/dist to build tracker 'C:\\Users\\VssAdministrator\\AppData\\Local\\Temp\\pip-req-tracker-j2qxfoak'
  Running setup.py (path:%SRC_DIR%\dist\setup.py) egg_info for package from file:///D:/bld/python-libarchive-c_1642883867449/work/dist
  Created temporary directory: C:\Users\VssAdministrator\AppData\Local\Temp\pip-pip-egg-info-kwop4uuv
  Running command python setup.py egg_info
  Preparing metadata (setup.py): started
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "D:\bld\python-libarchive-c_1642883867449\work\dist\setup.py", line 12, in <module>
      version=get_version(),
    File "D:\bld\python-libarchive-c_1642883867449\work\dist\version.py", line 39, in get_version
      version = version_re.search(f.read()).group(1)
    File "D:\bld\python-libarchive-c_1642883867449\_h_env\lib\encodings\cp1252.py", line 23, in decode
      return codecs.charmap_decode(input,self.errors,decoding_table)[0]
  UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 4499: character maps to <undefined>
WARNING: Discarding file:///D:/bld/python-libarchive-c_1642883867449/work/dist. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
  Preparing metadata (setup.py): finished with status 'error'
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

I guess a follow-on might be to do some testing on non-linux platforms on CI.

Thanks again!