### PR TITLE
Add non-recursive process mode for add_files in ArchiveWrite class

### DIFF
--- a/libarchive/write.py
+++ b/libarchive/write.py
@@ -44,7 +44,9 @@ class ArchiveWrite:
             write_finish_entry(write_p)
 
     def add_files(
-        self, *paths, flags=0, lookup=False, pathname=None, **attributes
+        self, *paths, flags=0, lookup=False,
+        pathname=None, recursive=True,
+        **attributes
     ):
         """Read files through the OS and add them to the archive.
 
@@ -58,6 +60,9 @@ class ArchiveWrite:
                 is called to enable the lookup of user and group names
             pathname (str | None):
                 the path of the file in the archive, defaults to the source path
+            recursive (bool):
+                when False, if a path in `paths` is a directory,
+                only the directory itself is added.
             attributes (dict): passed to `ArchiveEntry.modify()`
 
         Raises:
@@ -103,6 +108,8 @@ class ArchiveWrite:
                                 write_data(write_p, data, len(data))
                     write_finish_entry(write_p)
                     entry_clear(entry_p)
+                    if not recursive:
+                        break
 
     def add_file(self, path, **kw):
         "Single-path alias of `add_files()`"

--- a/libarchive/write.py
+++ b/libarchive/write.py
@@ -112,7 +112,10 @@ class ArchiveWrite:
                         break
 
     def add_file(self, path, **kw):
-        "Single-path alias of `add_files()`"
+        """
+        Single-path alias of `add_files()` without recursive process
+        """
+        kw['recursive'] = False
         return self.add_files(path, **kw)
 
     def add_file_from_memory(


### PR DESCRIPTION
Add non-recursive file process for function `add_files` with option `recursive`, also limit `add_file` only process the entry itself.

Example mtree output for non-recursive mode
```
#mtree
/set type=file uid=0 gid=0 mode=644
./__init__.py time=1644734613.0 size=601
./entry.py time=1644734613.0 size=12807
./exception.py time=1644734613.0 size=370
./extract.py time=1644734613.0 size=2694
./ffi.py time=1644734613.0 size=12247
./flags.py time=1644734613.0 size=211
./read.py time=1644734613.0 size=5514
./write.py time=1644734613.0 size=10227
./__pycache__ time=1644734613.0 mode=755 type=dir
```