### PR TITLE
Add bindings to change symlink read behavior.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,14 @@ and the optional third argument is the compression format (called “filter” i
 libarchive). The acceptable values are listed in ``libarchive.ffi.WRITE_FORMATS``
 and ``libarchive.ffi.WRITE_FILTERS``.
 
+Symbolic links
+~~~~~~~~~~~~~~
+
+By default, libarchive preserves symbolic links. If you want it to resolve the
+links and archive the files they point to instead, pass ``symlink_mode='logical'``
+when calling the ``add_files`` method. If you do that, an ``ArchiveError``
+exception will be raised when a symbolic link points to a nonexistent file.
+
 File metadata codecs
 --------------------
 

--- a/libarchive/ffi.py
+++ b/libarchive/ffi.py
@@ -286,9 +286,9 @@ ffi('read_disk_set_standard_lookup', [c_archive_p], c_int, check_int)
 ffi('read_disk_open', [c_archive_p, c_char_p], c_int, check_int)
 ffi('read_disk_open_w', [c_archive_p, c_wchar_p], c_int, check_int)
 ffi('read_disk_descend', [c_archive_p], c_int, check_int)
-ffi('read_disk_set_symlink_hybrid', [c_archive_p], c_int)
-ffi('read_disk_set_symlink_logical', [c_archive_p], c_int)
-ffi('read_disk_set_symlink_physical', [c_archive_p], c_int)
+ffi('read_disk_set_symlink_hybrid', [c_archive_p], c_int, check_int)
+ffi('read_disk_set_symlink_logical', [c_archive_p], c_int, check_int)
+ffi('read_disk_set_symlink_physical', [c_archive_p], c_int, check_int)
 
 # archive_read_data
 

--- a/libarchive/ffi.py
+++ b/libarchive/ffi.py
@@ -35,9 +35,6 @@ ARCHIVE_WARN = -20    # Partial success.
 ARCHIVE_FAILED = -25  # Current operation cannot complete.
 ARCHIVE_FATAL = -30   # No more operations are possible.
 
-ARCHIVE_SYMLINK_MODE_HYBRID = 'H'
-ARCHIVE_SYMLINK_MODE_LOGICAL = 'L'
-ARCHIVE_SYMLINK_MODE_PHYSICAL = 'P'
 
 # Callback types
 

--- a/libarchive/ffi.py
+++ b/libarchive/ffi.py
@@ -35,6 +35,9 @@ ARCHIVE_WARN = -20    # Partial success.
 ARCHIVE_FAILED = -25  # Current operation cannot complete.
 ARCHIVE_FATAL = -30   # No more operations are possible.
 
+ARCHIVE_SYMLINK_MODE_HYBRID = 'H'
+ARCHIVE_SYMLINK_MODE_LOGICAL = 'L'
+ARCHIVE_SYMLINK_MODE_PHYSICAL = 'P'
 
 # Callback types
 
@@ -286,6 +289,9 @@ ffi('read_disk_set_standard_lookup', [c_archive_p], c_int, check_int)
 ffi('read_disk_open', [c_archive_p, c_char_p], c_int, check_int)
 ffi('read_disk_open_w', [c_archive_p, c_wchar_p], c_int, check_int)
 ffi('read_disk_descend', [c_archive_p], c_int, check_int)
+ffi('read_disk_set_symlink_hybrid', [c_archive_p], c_int)
+ffi('read_disk_set_symlink_logical', [c_archive_p], c_int)
+ffi('read_disk_set_symlink_physical', [c_archive_p], c_int)
 
 # archive_read_data
 

--- a/libarchive/write.py
+++ b/libarchive/write.py
@@ -46,7 +46,7 @@ class ArchiveWrite:
 
     def add_files(
         self, *paths, flags=0, lookup=False, pathname=None, recursive=True,
-        symlink_mode=ffi.ARCHIVE_SYMLINK_MODE_PHYSICAL, **attributes
+        symlink_mode=None, **attributes
     ):
         """Read files through the OS and add them to the archive.
 
@@ -63,11 +63,9 @@ class ArchiveWrite:
             recursive (bool):
                 when False, if a path in `paths` is a directory,
                 only the directory itself is added.
-            symlink_mode (enum):
-                Determines how symlinks are traversed. Valid options are
-                ARCHIVE_SYMLINK_MODE_HYBRID, ARCHIVE_SYMLINK_MODE_LOGICAL, and
-                ARCHIVE_SYMLINK_MODE_PHYSICAL as defined in the ffi module.
-                Default value matches default from libarchive.
+            symlink_mode (Literal['hybrid', 'logical', 'physical'] | None):
+                how symbolic links should be handled; see `man archive_read_disk`
+                for meanings
             attributes (dict): passed to `ArchiveEntry.modify()`
 
         Raises:
@@ -80,18 +78,23 @@ class ArchiveWrite:
         if block_size <= 0:
             block_size = 10240  # pragma: no cover
 
+        set_symlink_mode = None
+        if symlink_mode:
+            try:
+                set_symlink_mode = getattr(
+                    ffi, f'read_disk_set_symlink_{symlink_mode}'
+                )
+            except AttributeError:
+                raise ValueError(
+                    f"symlink_mode value {symlink_mode!r} is invalid"
+                ) from None
+
         entry = ArchiveEntry(header_codec=self.header_codec)
         entry_p = entry._entry_p
         for path in paths:
             with new_archive_read_disk(path, flags, lookup) as read_p:
-                if (symlink_mode == ffi.ARCHIVE_SYMLINK_MODE_PHYSICAL):
-                    ffi.read_disk_set_symlink_physical(read_p)
-                elif (symlink_mode == ffi.ARCHIVE_SYMLINK_MODE_LOGICAL):
-                    ffi.read_disk_set_symlink_logical(read_p)
-                elif (symlink_mode == ffi.ARCHIVE_SYMLINK_MODE_HYBRID):
-                    ffi.read_disk_set_symlink_hybrid(read_p)
-                else:
-                    raise ValueError(f"Bad symlink mode value {symlink_mode}")
+                if set_symlink_mode:
+                    set_symlink_mode(read_p)
                 while 1:
                     r = read_next_header2(read_p, entry_p)
                     if r == ARCHIVE_EOF:

--- a/libarchive/write.py
+++ b/libarchive/write.py
@@ -46,7 +46,7 @@ class ArchiveWrite:
 
     def add_files(
         self, *paths, flags=0, lookup=False, pathname=None, recursive=True,
-        **attributes
+        symlink_mode=ffi.ARCHIVE_SYMLINK_MODE_PHYSICAL, **attributes
     ):
         """Read files through the OS and add them to the archive.
 
@@ -63,6 +63,11 @@ class ArchiveWrite:
             recursive (bool):
                 when False, if a path in `paths` is a directory,
                 only the directory itself is added.
+            symlink_mode (enum):
+                Determines how symlinks are traversed. Valid options are
+                ARCHIVE_SYMLINK_MODE_HYBRID, ARCHIVE_SYMLINK_MODE_LOGICAL, and
+                ARCHIVE_SYMLINK_MODE_PHYSICAL as defined in the ffi module.
+                Default value matches default from libarchive.
             attributes (dict): passed to `ArchiveEntry.modify()`
 
         Raises:
@@ -79,6 +84,14 @@ class ArchiveWrite:
         entry_p = entry._entry_p
         for path in paths:
             with new_archive_read_disk(path, flags, lookup) as read_p:
+                if (symlink_mode == ffi.ARCHIVE_SYMLINK_MODE_PHYSICAL):
+                    ffi.read_disk_set_symlink_physical(read_p)
+                elif (symlink_mode == ffi.ARCHIVE_SYMLINK_MODE_LOGICAL):
+                    ffi.read_disk_set_symlink_logical(read_p)
+                elif (symlink_mode == ffi.ARCHIVE_SYMLINK_MODE_HYBRID):
+                    ffi.read_disk_set_symlink_hybrid(read_p)
+                else:
+                    raise ValueError(f"Bad symlink mode value {symlink_mode}")
                 while 1:
                     r = read_next_header2(read_p, entry_p)
                     if r == ARCHIVE_EOF:


### PR DESCRIPTION
Add bindings to change symlink read behavior. Unfortunately, libarchive does not seem to have a way of getting the current setting, so only the setter was implemented.

Closes: #132

Signed-off-by: Nicholas Vinson <nvinson234@gmail.com>