### PR TITLE
Add read-write access to digests stored in archive entries

### DIFF
--- a/libarchive/entry.py
+++ b/libarchive/entry.py
@@ -86,12 +86,12 @@ class ArchiveEntry:
             rdev (int | Tuple[int, int]): device number, if the file is a device
             rdevmajor (int): major part of the device number
             rdevminor (int): minor part of the device number
-            md5Digest (bytes): MD5 digest
-            rmd160Digest (bytes): RMD160 digest
-            sha1Digest (bytes): SHA1 digest
-            sha256Digest (bytes): SHA256 digest
-            sha384Digest (bytes): SHA384 digest
-            sha512Digest (bytes): SHA512 digest
+            md5digest (bytes): MD5 digest
+            rmd160digest (bytes): RMD160 digest
+            sha1digest (bytes): SHA1 digest
+            sha256digest (bytes): SHA256 digest
+            sha384digest (bytes): SHA384 digest
+            sha512digest (bytes): SHA512 digest
         """
         if header_codec:
             self.header_codec = header_codec
@@ -440,58 +440,58 @@ class ArchiveEntry:
         ffi.entry_set_rdevminor(self._entry_p, value)
 
     @property
-    def md5Digest(self):
+    def md5digest(self):
         return self._digest(ffi.ARCHIVE_ENTRY_DIGEST_MD5)
 
-    @md5Digest.setter
-    def md5Digest(self, value):
+    @md5digest.setter
+    def md5digest(self, value):
         self._set_digest(ffi.ARCHIVE_ENTRY_DIGEST_MD5, value)
 
     @property
-    def rmd160Digest(self):
+    def rmd160digest(self):
         return self._digest(ffi.ARCHIVE_ENTRY_DIGEST_RMD160)
 
-    @rmd160Digest.setter
-    def rmd160Digest(self, value):
+    @rmd160digest.setter
+    def rmd160digest(self, value):
         self._set_digest(ffi.ARCHIVE_ENTRY_DIGEST_RMD160, value)
 
     @property
-    def sha1Digest(self):
+    def sha1digest(self):
         return self._digest(ffi.ARCHIVE_ENTRY_DIGEST_SHA1)
 
-    @sha1Digest.setter
-    def sha1Digest(self, value):
+    @sha1digest.setter
+    def sha1digest(self, value):
         self._set_digest(ffi.ARCHIVE_ENTRY_DIGEST_SHA1, value)
 
     @property
-    def sha256Digest(self):
+    def sha256digest(self):
         return self._digest(ffi.ARCHIVE_ENTRY_DIGEST_SHA256)
 
-    @sha256Digest.setter
-    def sha256Digest(self, value):
+    @sha256digest.setter
+    def sha256digest(self, value):
         self._set_digest(ffi.ARCHIVE_ENTRY_DIGEST_SHA256, value)
 
     @property
-    def sha384Digest(self):
+    def sha384digest(self):
         return self._digest(ffi.ARCHIVE_ENTRY_DIGEST_SHA384)
 
-    @sha384Digest.setter
-    def sha384Digest(self, value):
+    @sha384digest.setter
+    def sha384digest(self, value):
         self._set_digest(ffi.ARCHIVE_ENTRY_DIGEST_SHA384, value)
 
     @property
-    def sha512Digest(self):
+    def sha512digest(self):
         return self._digest(ffi.ARCHIVE_ENTRY_DIGEST_SHA512)
 
-    @sha512Digest.setter
-    def sha512Digest(self, value):
+    @sha512digest.setter
+    def sha512digest(self, value):
         self._set_digest(ffi.ARCHIVE_ENTRY_DIGEST_SHA512, value)
 
-    def _digest(self, digestType):
+    def _digest(self, digest_type):
         try:
-            ptr = ffi.entry_digest(self._entry_p, digestType)
+            ptr = ffi.entry_digest(self._entry_p, digest_type)
             if ptr:
-                return bytes(ptr[:ffi._DIGEST_LENGTHS[digestType - 1]])
+                return bytes(ptr[:ffi._DIGEST_LENGTHS[digest_type - 1]])
         except AttributeError:
             raise NotImplementedError(f"the libarchive being used (version "
                                       f"{ffi.version_number()} path "
@@ -499,14 +499,14 @@ class ArchiveEntry:
                                       f"support read-only digest APIs")
         return None
 
-    def _set_digest(self, digestType, value):
+    def _set_digest(self, digest_type, value):
         try:
-            digestLen = ffi._DIGEST_LENGTHS[digestType - 1]
-            if len(value) != digestLen:
-                raise ValueError(f"Invalid input digest Expected {digestLen} "
+            digest_length = ffi._DIGEST_LENGTHS[digest_type - 1]
+            if len(value) != digest_length:
+                raise ValueError(f"Invalid input digest Expected {digest_length} "
                                  f"bytes. Got {len(value)}.")
-            buffer = (digestLen * ffi.c_ubyte)(*value)
-            ffi.entry_set_digest(self._entry_p, digestType, buffer)
+            buffer = (digest_length * ffi.c_ubyte)(*value)
+            ffi.entry_set_digest(self._entry_p, digest_type, buffer)
         except AttributeError:
             raise NotImplementedError(f"the libarchive being used (version "
                                       f"{ffi.version_number()} path "

--- a/libarchive/entry.py
+++ b/libarchive/entry.py
@@ -437,6 +437,14 @@ class ArchiveEntry:
 
     @property
     def stored_digests(self):
+        """The file's hashes stored in the archive.
+
+        libarchive only supports reading and writing digests from and to 'mtree'
+        files. Setting the digests requires at least version 3.8.0 of libarchive
+        (released in May 2025). It also requires including the names of the
+        digest algorithms in the string of options passed to the archive writer
+        (e.g. `file_writer(archive_path, 'mtree', options='md5,rmd160,sha256')`).
+        """
         return {name: self.get_stored_digest(name) for name in ffi.DIGEST_ALGORITHMS}
 
     @stored_digests.setter

--- a/libarchive/entry.py
+++ b/libarchive/entry.py
@@ -87,12 +87,7 @@ class ArchiveEntry:
             rdev (int | Tuple[int, int]): device number, if the file is a device
             rdevmajor (int): major part of the device number
             rdevminor (int): minor part of the device number
-            md5 (bytes): MD5 digest
-            rmd160 (bytes): RMD160 digest
-            sha1 (bytes): SHA1 digest
-            sha256 (bytes): SHA256 digest
-            sha384 (bytes): SHA384 digest
-            sha512 (bytes): SHA512 digest
+            stored_digests (dict[str, bytes]): hashes of the file's contents
         """
         if header_codec:
             self.header_codec = header_codec
@@ -441,52 +436,13 @@ class ArchiveEntry:
         ffi.entry_set_rdevminor(self._entry_p, value)
 
     @property
-    def md5(self):
-        return self.get_stored_digest('md5')
+    def stored_digests(self):
+        return {name: self.get_stored_digest(name) for name in ffi.DIGEST_ALGORITHMS}
 
-    @md5.setter
-    def md5(self, value):
-        self.set_stored_digest('md5', value)
-
-    @property
-    def rmd160(self):
-        return self.get_stored_digest('rmd160')
-
-    @rmd160.setter
-    def rmd160(self, value):
-        self.set_stored_digest('rmd160', value)
-
-    @property
-    def sha1(self):
-        return self.get_stored_digest('sha1')
-
-    @sha1.setter
-    def sha1(self, value):
-        self.set_stored_digest('sha1', value)
-
-    @property
-    def sha256(self):
-        return self.get_stored_digest('sha256')
-
-    @sha256.setter
-    def sha256(self, value):
-        self.set_stored_digest('sha256', value)
-
-    @property
-    def sha384(self):
-        return self.get_stored_digest('sha384')
-
-    @sha384.setter
-    def sha384(self, value):
-        self.set_stored_digest('sha384', value)
-
-    @property
-    def sha512(self):
-        return self.get_stored_digest('sha512')
-
-    @sha512.setter
-    def sha512(self, value):
-        self.set_stored_digest('sha512', value)
+    @stored_digests.setter
+    def stored_digests(self, values):
+        for name, value in values.items():
+            self.set_stored_digest(name, value)
 
     def get_stored_digest(self, algorithm_name):
         algorithm = ffi.DIGEST_ALGORITHMS[algorithm_name]

--- a/libarchive/entry.py
+++ b/libarchive/entry.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from ctypes import create_string_buffer
+from ctypes import create_string_buffer, string_at
 from enum import IntEnum
 import math
 
@@ -502,7 +502,7 @@ class ArchiveEntry:
                 f"the libarchive being used (version {ffi.version_number()}, path "
                 f"{ffi.libarchive_path}) doesn't support {algorithm_name} digests"
             ) from None
-        return bytes(ptr[:algorithm.bytes_length])
+        return string_at(ptr, algorithm.bytes_length)
 
     def set_stored_digest(self, algorithm_name, value):
         algorithm = ffi.DIGEST_ALGORITHMS[algorithm_name]
@@ -516,7 +516,7 @@ class ArchiveEntry:
             retcode = ffi.entry_set_digest(
                 self._entry_p,
                 algorithm.libarchive_id,
-                (expected_length * ffi.c_ubyte)(*value)
+                (expected_length * ffi.c_ubyte).from_buffer_copy(value)
             )
         except AttributeError:
             raise NotImplementedError(

--- a/libarchive/ffi.py
+++ b/libarchive/ffi.py
@@ -366,38 +366,41 @@ except AttributeError:
         f"path {libarchive_path}) doesn't support encryption"
     )
 
-# archive digest API
+
+# archive entry digests (a.k.a. hashes)
+
+class DigestAlgorithm:
+    __slots__ = ('name', 'libarchive_id', 'bytes_length')
+
+    def __init__(self, name, libarchive_id, bytes_length):
+        self.name = name
+        self.libarchive_id = libarchive_id
+        self.bytes_length = bytes_length
+
+
+DIGEST_ALGORITHMS = {
+    'md5': DigestAlgorithm('md5', libarchive_id=1, bytes_length=16),
+    'rmd160': DigestAlgorithm('rmd160', libarchive_id=2, bytes_length=20),
+    'sha1': DigestAlgorithm('sha1', libarchive_id=3, bytes_length=20),
+    'sha256': DigestAlgorithm('sha256', libarchive_id=4, bytes_length=32),
+    'sha384': DigestAlgorithm('sha384', libarchive_id=5, bytes_length=48),
+    'sha512': DigestAlgorithm('sha512', libarchive_id=6, bytes_length=64),
+}
+
 try:
-    ffi('entry_digest', [c_archive_entry_p, c_int], POINTER(c_ubyte))
-
-    ARCHIVE_ENTRY_DIGEST_MD5 = 1
-    ARCHIVE_ENTRY_DIGEST_RMD160 = 2
-    ARCHIVE_ENTRY_DIGEST_SHA1 = 3
-    ARCHIVE_ENTRY_DIGEST_SHA256 = 4
-    ARCHIVE_ENTRY_DIGEST_SHA384 = 5
-    ARCHIVE_ENTRY_DIGEST_SHA512 = 6
-
-    _DIGEST_LENGTHS = [
-        16,  # MD5
-        20,  # RMD160
-        20,  # SHA1
-        32,  # SHA256
-        48,  # SHA384
-        64,  # SHA512
-    ]
-
+    ffi('entry_digest', [c_archive_entry_p, c_int], POINTER(c_ubyte), check_null)
 except AttributeError:
     logger.info(
         f"the libarchive being used (version {version_number()}, "
-        f"path {libarchive_path}) doesn't support read-only message digest API"
+        f"path {libarchive_path}) doesn't support reading entry digests"
     )
 
 try:
     ffi('entry_set_digest',
-        [ctypes.c_void_p, ctypes.c_int, ctypes.POINTER(ctypes.c_ubyte)],
-        ctypes.c_int)
+        [c_archive_entry_p, c_int, POINTER(c_ubyte)],
+        c_int, check_int)
 except AttributeError:
     logger.info(
         f"the libarchive being used (version {version_number()}, "
-        f"path {libarchive_path}) doesn't support mutable message digest API"
+        f"path {libarchive_path}) doesn't support modifying entry digests"
     )

--- a/libarchive/ffi.py
+++ b/libarchive/ffi.py
@@ -1,6 +1,6 @@
 from ctypes import (
     c_char_p, c_int, c_uint, c_long, c_longlong, c_size_t, c_int64,
-    c_void_p, c_wchar_p, CFUNCTYPE, POINTER,
+    c_ubyte, c_void_p, c_wchar_p, CFUNCTYPE, POINTER,
 )
 
 try:
@@ -364,4 +364,40 @@ except AttributeError:
     logger.info(
         f"the libarchive being used (version {version_number()}, "
         f"path {libarchive_path}) doesn't support encryption"
+    )
+
+# archive digest API
+try:
+    ffi('entry_digest', [c_archive_entry_p, c_int], POINTER(c_ubyte))
+
+    ARCHIVE_ENTRY_DIGEST_MD5 = 1
+    ARCHIVE_ENTRY_DIGEST_RMD160 = 2
+    ARCHIVE_ENTRY_DIGEST_SHA1 = 3
+    ARCHIVE_ENTRY_DIGEST_SHA256 = 4
+    ARCHIVE_ENTRY_DIGEST_SHA384 = 5
+    ARCHIVE_ENTRY_DIGEST_SHA512 = 6
+
+    _DIGEST_LENGTHS = [
+        16,  # MD5
+        20,  # RMD160
+        20,  # SHA1
+        32,  # SHA256
+        48,  # SHA384
+        64,  # SHA512
+    ]
+
+except AttributeError:
+    logger.info(
+        f"the libarchive being used (version {version_number()}, "
+        f"path {libarchive_path}) doesn't support read-only message digest API"
+    )
+
+try:
+    ffi('entry_set_digest',
+        [ctypes.c_void_p, ctypes.c_int, ctypes.POINTER(ctypes.c_ubyte)],
+        ctypes.c_int)
+except AttributeError:
+    logger.info(
+        f"the libarchive being used (version {version_number()}, "
+        f"path {libarchive_path}) doesn't support mutable message digest API"
     )

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -175,8 +175,7 @@ def test_writing_and_reading_entry_digests(tmpdir):
     archive_path = str(tmpdir / 'mtree')
     with file_writer(archive_path, 'mtree') as archive:
         # Add an empty file, with fake hashes.
-        archive.add_file_from_memory('empty.txt', 0, b'', **fake_hashes)
+        archive.add_file_from_memory('empty.txt', 0, b'', stored_digests=fake_hashes)
     with file_reader(archive_path) as archive:
         entry = next(iter(archive))
-        for key, value in fake_hashes.items():
-            assert getattr(entry, key) == value
+        assert entry.stored_digests == fake_hashes

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from codecs import open
 import json
 import locale
 from os import environ, stat
@@ -14,8 +11,6 @@ from libarchive.entry import ArchiveEntry, ConsumedArchiveEntry, PassedArchiveEn
 
 from . import data_dir, get_entries, get_tarinfos
 
-
-text_type = unicode if str is bytes else str  # noqa: F821
 
 locale.setlocale(locale.LC_ALL, '')
 
@@ -106,7 +101,7 @@ def check_entries(test_file, regen=False, ignore=''):
         # Normalize all unicode (can vary depending on the system)
         for d in (e1, e2):
             for key in d:
-                if isinstance(d[key], text_type):
+                if isinstance(d[key], str):
                     d[key] = unicodedata.normalize('NFC', d[key])
         assert e1 == e2
 

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -162,9 +162,9 @@ fake_hashes = dict(
 )
 mtree = (
     '#mtree\n'
-    './empty.txt nlink=0 time=0.0 mode=664 gid=0 uid=0 type=file size=0 '
-    f'md5={'21'*16} rmd160={'21'*20} sha1={'21'*20} sha256={'21'*32} '
-    f'sha384={'21'*48} sha512={'21'*64}\n'
+    './empty.txt nlink=0 time=0.0 mode=664 gid=0 uid=0 type=file size=42 '
+    f'md5digest={'21'*16} rmd160digest={'21'*20} sha1digest={'21'*20} '
+    f'sha256digest={'21'*32} sha384digest={'21'*48} sha512digest={'21'*64}\n'
 )
 
 
@@ -180,9 +180,10 @@ def test_reading_entry_digests(tmpdir):
 )
 def test_writing_entry_digests(tmpdir):
     archive_path = str(tmpdir / 'mtree')
-    with file_writer(archive_path, 'mtree') as archive:
+    options = ','.join(fake_hashes.keys())
+    with file_writer(archive_path, 'mtree', options=options) as archive:
         # Add an empty file, with fake hashes.
-        archive.add_file_from_memory('empty.txt', 0, b'', stored_digests=fake_hashes)
+        archive.add_file_from_memory('empty.txt', 42, (), stored_digests=fake_hashes)
     with open(archive_path) as f:
         libarchive_mtree = f.read()
         assert libarchive_mtree == mtree


### PR DESCRIPTION
Supersedes #136.

@nvinson Writing the digests doesn't actually work. https://github.com/libarchive/libarchive/pull/2540 wasn't enough, because the mtree writer only writes [the digests it has computed itself](https://github.com/libarchive/libarchive/blob/992a596290057695242558798b7929e0112e5b3d/libarchive/archive_write_set_format_mtree.c#L85), not [the ones stored in the archive entry](https://github.com/libarchive/libarchive/blob/992a596290057695242558798b7929e0112e5b3d/libarchive/archive_entry_private.h#L177).